### PR TITLE
Fixed WPF Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ presenter.Show();
 ### WPF
 
 ```csharp
-var view = new WebcamCapturerWindow()
-var presenter = new WebcamCapturePresenter(view);
-presenter.Show();
+ var view = new WebcamCaptureWindow();
+ new WebcamCapturePresenter(view);
+ view.Show();
 ```


### PR DESCRIPTION
There is no `Show()` method on `WebcamCapturePresenter`